### PR TITLE
Use setImmediate instead of process.nextTick to suppress nodejs deprecation warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ S3StreamLogger.prototype._write = function(chunk, encoding, cb){
     // Call the callback immediately, as we may not actually write for some
     // time. If there is an upload error, we trigger our 'error' event.
     if(cb && typeof cb === 'function')
-        process.nextTick(cb);
+        setImmediate(cb);
 };
 
 module.exports = {


### PR DESCRIPTION
Current code causes the warning: 
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
