### PR TITLE
Data drop fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function S3StreamLogger(options){
     this.bucket                 = options.bucket || process.env.BUCKET_NAME;
     this.name_format            = options.name_format   || '%Y-%m-%d-%H-%M-unknown-unknown.log';
     this.rotate_every           = options.rotate_every  || 60*60*1000; // default to 60 minutes
-    this.max_file_size          = options.max_file_size || 200000      // or 200k, whichever is sooner
+    this.max_file_size          = options.max_file_size || 200000;     // or 200k, whichever is sooner
     this.upload_every           = options.upload_every  || 20*1000;    // default to 20 seconds
     this.buffer_size            = options.buffer_size   || 10000;      // or every 10k, which ever is sooner
     this.server_side_encryption = options.server_side_encryption || false;
@@ -38,7 +38,6 @@ function S3StreamLogger(options){
     this.last_write   = null;
     this.buffers      = [];
     this.unwritten    = 0;
-    this.file_size    = 0;
 
     this._newFile();
 }
@@ -48,7 +47,7 @@ util.inherits(S3StreamLogger, stream.Writable);
 S3StreamLogger.prototype.flushFile = function(){
     this._upload();
     this._newFile();
-}
+};
 
 
 // Private API
@@ -79,7 +78,7 @@ S3StreamLogger.prototype._upload = function(){
        buffer.length > this.max_file_size){
         this._newFile();
     }
-}
+};
 
 // _newFile should ONLY be called when there is no un-uploaded data (i.e.
 // immediately after _upload), otherwise data will be lost
@@ -90,7 +89,7 @@ S3StreamLogger.prototype._newFile = function(){
     this.last_write   = this.file_started;
     // create a date object with the UTC version of the date to use with
     // strftime, so that the commonly use formatters return the UTC values.
-    // This breaks timezone-converting specifers (as they will convert against
+    // This breaks timezone-converting specifiers (as they will convert against
     // the wrong timezone).
     var date_as_utc = new Date(
         this.file_started.getUTCFullYear(),
@@ -101,7 +100,7 @@ S3StreamLogger.prototype._newFile = function(){
         this.file_started.getUTCSeconds()
     );
     this.object_name  = strftime(this.name_format, date_as_utc);
-}
+};
 
 S3StreamLogger.prototype._write = function(chunk, encoding, cb){
     if(typeof chunk === 'string')

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function S3StreamLogger(options){
         throw new Error("options.secret_access_key or AWS_SECRET_ACCESS_KEY environment variable is required");
 
     this.bucket                 = options.bucket || process.env.BUCKET_NAME;
-    this.name_format            = options.name_format   || '%Y-%m-%d-%H-%M-unknown-unknown.log';
+    this.name_format            = options.name_format   || '%Y-%m-%d-%H-%M-%S-%L-unknown-unknown.log';
     this.rotate_every           = options.rotate_every  || 60*60*1000; // default to 60 minutes
     this.max_file_size          = options.max_file_size || 200000;     // or 200k, whichever is sooner
     this.upload_every           = options.upload_every  || 20*1000;    // default to 20 seconds
@@ -97,7 +97,8 @@ S3StreamLogger.prototype._newFile = function(){
         this.file_started.getUTCDate(),
         this.file_started.getUTCHours(),
         this.file_started.getUTCMinutes(),
-        this.file_started.getUTCSeconds()
+        this.file_started.getUTCSeconds(),
+        this.file_started.getUTCMilliseconds()
     );
     this.object_name  = strftime(this.name_format, date_as_utc);
 };


### PR DESCRIPTION
This PR fixes three issues that come up when pushing megabytes of data through s3-streamlogger:

1. `last_write` wasn't reset in _upload, so every write after the initial upload_every seconds immediately writes
1. if enough data comes through to cause a rotation in the first second, there was no way to distinguish the filenames, because _newFile didn't keep the milliseconds (and the default name_format didn't use anything more granular than minutes!), so s3-streamlogger just overwrote the previous file, causing loss of the entire previous log
1. during periods of high write volume, calling `s3.putObject` allowed the possibility of further writes between the buffer collection and buffer zeroing in _newFile, causing less systematic data loss in the middle of otherwise good logs

My test case involved pushing 8-10 MB of logs involving writes of less than 1K each.  There was another issue where sending tens of thousands of putObject calls in a few seconds completely crashed node.js, but this is probably below the level of s3-streamlogger, and fix number 1 above means that this doesn't happen any more, anyway.