### PR TITLE
Allow users direct control over AWS SDK configuration object

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,22 @@ function S3StreamLogger(options){
     this.buffer_size            = options.buffer_size   || 10000;      // or every 10k, which ever is sooner
     this.server_side_encryption = options.server_side_encryption || false;
 
-    this.s3           = new aws.S3({
-        secretAccessKey: options.secret_access_key,
-            accessKeyId: options.access_key_id,
-             sslEnabled:true
-    });
+    // Backwards compatible API changes
+
+    options.config = options.config || {};
+    if(options.access_key_id) {
+      console.log('s3-streamlogger WARN: access_key_id is deprecated. Use config.accessKeyId instead.');
+      options.config.accessKeyId = options.access_key_id;
+    }
+    if(options.secret_access_key) {
+      console.log('s3-streamlogger WARN: secret_access_key is deprecated. Use config.secretAccessKey instead.');
+      options.config.secretAccessKey = options.secret_access_key;
+    }
+    if(options.config.sslEnabled === undefined) {
+      options.config.sslEnabled = true;
+    }
+
+    this.s3           = new aws.S3(options.config);
     this.timeout      = null;
     this.object_name  = null;
     this.file_started = null;

--- a/index.js
+++ b/index.js
@@ -27,11 +27,9 @@ function S3StreamLogger(options){
 
     options.config = options.config || {};
     if(options.access_key_id) {
-      console.log('s3-streamlogger WARN: access_key_id is deprecated. Use config.accessKeyId instead.');
       options.config.accessKeyId = options.access_key_id;
     }
     if(options.secret_access_key) {
-      console.log('s3-streamlogger WARN: secret_access_key is deprecated. Use config.secretAccessKey instead.');
       options.config.secretAccessKey = options.secret_access_key;
     }
     if(options.config.sslEnabled === undefined) {

--- a/readme.md
+++ b/readme.md
@@ -18,9 +18,11 @@ npm install --save s3-streamlogger
 var S3StreamLogger = require('s3-streamlogger').S3StreamLogger;
 
 var s3stream = new S3StreamLogger({
-               bucket: "mys3bucket",
-        access_key_id: "...",
-    secret_access_key: "..."
+             bucket: "mys3bucket",
+             config: {
+                          accessKeyId: "...",
+                      secretAccessKey: "..."
+             }
 });
 
 s3stream.write("hello S3");
@@ -38,8 +40,10 @@ var S3StreamLogger = require('s3-streamlogger').S3StreamLogger;
 
 var s3_stream = new S3StreamLogger({
              bucket: "mys3bucket",
-      access_key_id: "...",
-  secret_access_key: "..."
+             config: {
+                          accessKeyId: "...",
+                      secretAccessKey: "..."
+             }
 });
 
 var logger = new (winston.Logger)({
@@ -86,19 +90,9 @@ s3_stream.on('error', function(err){
 Name of the S3 bucket to upload data to. Must exist.
 Can also be provided as the environment variable `BUCKET_NAME`.
 
-#### access_key_id
-AWS access key ID, must have putObject permission on the specified bucket.  Can
-also be provided as the environment variable `AWS_SECRET_ACCESS_KEY`, or as any
-of the other [authentication
-methods](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html)
-supported by the AWS SDK.
+#### config
 
-#### secret_access_key
-AWS secret key for the `access_key_id` specified.  Can also be provided as the
-environment variable `AWS_SECRET_KEY_ID`, or as any of the other
-[authentication
-methods](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html)
-supported by the AWS SDK.
+Configuration object for the AWS SDK. The full list of options is available on the [AWS SDK Configuration Object page](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html).
 
 #### name_format
 Format of file names to create, accepts [strftime specifiers](https://github.com/samsonjs/strftime). Defaults to `"%Y-%m-%d-%H-%M-%S-%L-unknown-unknown.log"`. The Date() used to fill the format specifiers is created with the current UTC time, but still *has the current timezone*, so any specifiers that perform timezone conversion will return incorrect dates.

--- a/readme.md
+++ b/readme.md
@@ -18,11 +18,9 @@ npm install --save s3-streamlogger
 var S3StreamLogger = require('s3-streamlogger').S3StreamLogger;
 
 var s3stream = new S3StreamLogger({
-             bucket: "mys3bucket",
-             config: {
-                          accessKeyId: "...",
-                      secretAccessKey: "..."
-             }
+               bucket: "mys3bucket",
+        access_key_id: "...",
+    secret_access_key: "..."
 });
 
 s3stream.write("hello S3");
@@ -40,10 +38,8 @@ var S3StreamLogger = require('s3-streamlogger').S3StreamLogger;
 
 var s3_stream = new S3StreamLogger({
              bucket: "mys3bucket",
-             config: {
-                          accessKeyId: "...",
-                      secretAccessKey: "..."
-             }
+      access_key_id: "...",
+  secret_access_key: "..."
 });
 
 var logger = new (winston.Logger)({
@@ -90,9 +86,23 @@ s3_stream.on('error', function(err){
 Name of the S3 bucket to upload data to. Must exist.
 Can also be provided as the environment variable `BUCKET_NAME`.
 
+#### access_key_id
+AWS access key ID, must have putObject permission on the specified bucket.  Can
+also be provided as the environment variable `AWS_SECRET_ACCESS_KEY`, or as any
+of the other [authentication
+methods](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html)
+supported by the AWS SDK.
+
+#### secret_access_key
+AWS secret key for the `access_key_id` specified.  Can also be provided as the
+environment variable `AWS_SECRET_KEY_ID`, or as any of the other
+[authentication
+methods](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html)
+supported by the AWS SDK.
+
 #### config
 
-Configuration object for the AWS SDK. The full list of options is available on the [AWS SDK Configuration Object page](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html).
+Configuration object for the AWS SDK. The full list of options is available on the [AWS SDK Configuration Object page](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html). This is an alternative to using access_key_id and secret_access_key and is overwritten by them if both are used.
 
 #### name_format
 Format of file names to create, accepts [strftime specifiers](https://github.com/samsonjs/strftime). Defaults to `"%Y-%m-%d-%H-%M-%S-%L-unknown-unknown.log"`. The Date() used to fill the format specifiers is created with the current UTC time, but still *has the current timezone*, so any specifiers that perform timezone conversion will return incorrect dates.


### PR DESCRIPTION
This commit gives more control over the database connection, passing the configuration object directly to aws-sdk. It is fully backward compatible with the API.