### PR TITLE
Add an `acl` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function S3StreamLogger(options){
     this.upload_every           = options.upload_every  || 20*1000;    // default to 20 seconds
     this.buffer_size            = options.buffer_size   || 10000;      // or every 10k, which ever is sooner
     this.server_side_encryption = options.server_side_encryption || false;
+    this.acl                    = options.acl || false;
 
     // Backwards compatible API changes
 
@@ -84,6 +85,10 @@ S3StreamLogger.prototype._upload = function(forceNewFile) {
 
     if (this.server_side_encryption) {
         param.ServerSideEncryption = SERVER_SIDE_ENCRYPTION;
+    }
+
+    if (this.acl) {
+        param.ACL = this.acl;
     }
 
     this.unwritten = 0;

--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,10 @@ Defaults to 10 KB.
 The server side encryption `AES256` algorithm used when storing objects in S3.
 Defaults to false.
 
+#### acl
+The canned ACL (access control list) to apply to uploaded objects.
+Defaults to no ACL.
+
 
 ### License
 [ISC](http://opensource.org/licenses/ISC): equivalent to 2-clause BSD.


### PR DESCRIPTION
Adds the ability to set the `ACL` to be used for `s3.putObject`.