### PR TITLE
Add a callback parameter to S3StreamLogger.flushFile()

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,8 +70,8 @@ function S3StreamLogger(options){
 util.inherits(S3StreamLogger, stream.Writable);
 
 // write anything outstanding to the current file, and start a new one
-S3StreamLogger.prototype.flushFile = function(){
-    this._upload(true);
+S3StreamLogger.prototype.flushFile = function(cb){
+    this._upload(true, cb);
 };
 
 // Private API


### PR DESCRIPTION
This adds an optional callback parameter to `S3StreamLogger.prototype._upload()` and `S3StreamLogger.prototype.flushFile()`. The use-case for this is to be able to flush the buffer and wait for it to complete during graceful shutdowns.