### PR TITLE
Fix regression in 1.9.3 when using Instance Profiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,12 +39,16 @@ function S3StreamLogger(options){
     // Backwards compatible API changes
 
     options.config = options.config || {};
-    options.config.credentials = options.config.credentials || {};
-    if(options.access_key_id) {
-      options.config.credentials.accessKeyId = options.access_key_id;
-    }
-    if(options.secret_access_key) {
-      options.config.credentials.secretAccessKey = options.secret_access_key;
+    
+    //When using an Instance Profile these options will not be included therefore credentials should not be created
+    if(options.access_key_id || options.secret_access_key) {
+      options.config.credentials = options.config.credentials || {};
+      if(options.access_key_id) {
+        options.config.credentials.accessKeyId = options.access_key_id;
+      }
+      if(options.secret_access_key) {
+        options.config.credentials.secretAccessKey = options.secret_access_key;
+      }
     }
     if(options.config.sslEnabled === undefined) {
       options.config.sslEnabled = true;


### PR DESCRIPTION
This is to fix a regression introduced in 1.9.3.

Using an IAM Instance Profile to authenticate works in 1.9.2 but was broken in 1.9.3 with the following error:

`Resolved credential object is not valid
at _SignatureV4S3Express.validateResolvedCredentials (node_modules/@smithy/signature-v4/dist-cjs/index.js:562:13)
    at _SignatureV4S3Express.signRequest (node_modules/@smithy/signature-v4/dist-cjs/index.js:487:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

This fixes that by preventing creating an empty credentials object when neither access key nor secret key is specified